### PR TITLE
build: fix wrong pylint warning related to pydantic

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,3 +6,6 @@ disable=missing-docstring
 
 [MISCELLANEOUS]
 notes=FIXME,XXX
+
+[MASTER]
+extension-pkg-whitelist=pydantic ; https://github.com/pydantic/pydantic/issues/1961#issuecomment-759522422


### PR DESCRIPTION
I was having this error message in VS Code:

>  No name 'BaseModel' in module 'pydantic' (no-name-in-module)

As it is explained [here](https://github.com/pydantic/pydantic/issues/1961#issuecomment-759522422), the issue is related to the binary extensions. With this change we _"let Pylint know that it should import a C extension to build the AST from the live module"_.